### PR TITLE
0.0.13

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
             python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -32,7 +32,7 @@ jobs:
       run: pip list
 
     - name: Run tests and show coverage on the command line
-      run: coverage run --source=awaits --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m
+      run: coverage run --source=awaits --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=95
 
     - name: Upload reports to codecov
       env:

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -32,14 +32,15 @@ jobs:
       run: pip list
 
     - name: Run tests and show coverage on the command line
-      run: coverage run --source=awaits --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=95
-
-    - name: Upload reports to codecov
-      env:
-        CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
-      if: runner.os == 'Linux'
       run: |
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        find . -iregex "codecov.*"
-        chmod +x codecov
-        ./codecov -t ${CODECOV_TOKEN}
+        coverage run --source=awaits --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=95
+        coverage xml
+
+    - name: Upload coverage to Coveralls
+      if: runner.os == 'Linux'
+      env:
+        COVERALLS_REPO_TOKEN: ${{secrets.COVERALLS_REPO_TOKEN}}
+      uses: coverallsapp/github-action@v2
+      with:
+        format: cobertura
+        file: coverage.xml

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -10,12 +10,12 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
           python-version: ${{ matrix.python-version }}
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Downloads](https://static.pepy.tech/badge/awaits/month)](https://pepy.tech/project/awaits)
 [![Downloads](https://static.pepy.tech/badge/awaits)](https://pepy.tech/project/awaits)
-[![codecov](https://codecov.io/gh/pomponchik/awaits/graph/badge.svg?token=A5VJ4PUED7)](https://codecov.io/gh/pomponchik/awaits)
+[![Coverage Status](https://coveralls.io/repos/github/pomponchik/awaits/badge.svg?branch=main)](https://coveralls.io/github/pomponchik/awaits?branch=main)
 [![Hits-of-Code](https://hitsofcode.com/github/pomponchik/awaits?branch=main)](https://hitsofcode.com/github/pomponchik/awaits/view?branch=main)
 [![Tests](https://github.com/pomponchik/awaits/actions/workflows/tests_and_coverage.yml/badge.svg)](https://github.com/pomponchik/awaits/actions/workflows/tests_and_coverage.yml)
 [![Python versions](https://img.shields.io/pypi/pyversions/awaits.svg)](https://pypi.python.org/pypi/awaits)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ $ pip install awaits
 import asyncio
 from awaits import awaitable
 
-
 @awaitable
 def sum(a, b):
   # Какой-то сложный датасаенз. Что-то, что вычисляется долго и мешает вашему event-loop'у жить.
@@ -61,7 +60,6 @@ print(asyncio.run(sum(2, 2)))
 
 ```python
 from awaits import shoot
-
 
 @shoot
 def hello():
@@ -174,7 +172,6 @@ pool = room['some_key']
 ```python
 from awaits.task import Task
 
-
 def hello_something(something, sign='!'):
   hello_string = f'Hello {something}{sign}'
   print(hello_string)
@@ -223,7 +220,6 @@ if task.error:
 ```python
 from awaits import awaitable
 
-
 @awaitable
 def heavy_math_function(x, y):
   return x * y
@@ -263,7 +259,6 @@ def heavy_math_function(x, y):
 ```python
 from awaits import shoot
 
-
 @shoot
 def other_heavy_math_function(x, y):
   return x * y
@@ -294,7 +289,6 @@ def other_heavy_math_function(x, y):
 
 ```python
 from awaits import config
-
 
 # Для примера устанавливаем частоту опроса задачи в декораторе @awaitable на значение 0.5 сек.
 config.set(delay=10.5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: 3.13',
+  'Programming Language :: Python :: 3.14',
   'License :: OSI Approved :: MIT License',
   'Intended Audience :: Developers',
   'Topic :: Software Development :: Libraries',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'awaits'
-version = '0.0.12'
+version = '0.0.13'
 authors = [
   { name='Evgeniy Blinov', email='zheni-b@yandex.ru' },
 ]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 wheel==0.41.2
 twine==6.1.0
 build==1.2.2.post1
-pytest==7.4.3
+pytest==8.0.2
 coverage==7.6.1
 ruff==0.9.9
 mypy==1.14.1


### PR DESCRIPTION
A purely technical update, with no new functionality.

- Added full support for `Python 3.14`.
- `Python 3.14` and `3.14 free threading` runners added to CI. Also updated versions of some of the Github Actions used.
- The provider of the test coverage display changed to `Coveralls`.
- Updated 1 dev dependency.